### PR TITLE
glacier.vim: Set EndOfBuffer highlighting

### DIFF
--- a/colors/glacier.vim
+++ b/colors/glacier.vim
@@ -55,6 +55,7 @@ let g:terminal_color_15 = s:bright_white
 " basic editor colors
 exe "hi Normal guifg=".s:fg." guibg=".s:bg
 exe "hi LineNr guifg=".s:comment." guibg=".s:bg
+exe "hi EndOfBuffer guifg=".s:comment." guibg=".s:bg
 exe "hi CursorLine guibg=".s:bg_darker
 exe "hi CursorLineNr guifg=".s:bright_orange." gui=bold"
 exe "hi CursorColumn guibg=".s:white
@@ -147,4 +148,3 @@ exe "hi FileReadOnly guifg=".s:bright_red
 exe "hi FileExecutable guifg=".s:bright_green
 exe "hi FileSymlink guifg=".s:cyan
 exe "hi FileHidden guifg=".s:comment
-


### PR DESCRIPTION
```EndOfBuffer``` highlighting will be set as default color without this commit in the classic Vim.

This is a screenshot without this commit:
- Left: NeoVim
- Right: Classic Vim

<img width="2560" height="1408" alt="Screenshot From 2025-08-01 15-20-23" src="https://github.com/user-attachments/assets/3638329f-9505-4ab7-be53-10f100c13f11" />
